### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,5 @@
   "main": "index.js",
   "repository": "git@github.com:teleport-network/xibc-contracts.git",
   "author": "",
-  "license": "MIT"
+  "license": "Apache License 2.0"
 }


### PR DESCRIPTION
without the "package.json" file will cause projects that depend on this package when running "yarn hardhat compile" can't find this package even if it's in node_modules